### PR TITLE
Make StageUtils compatible with Java 8 and 9

### DIFF
--- a/src/main/java/de/codecentric/centerdevice/MenuToolkit.java
+++ b/src/main/java/de/codecentric/centerdevice/MenuToolkit.java
@@ -1,7 +1,11 @@
 package de.codecentric.centerdevice;
 
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.Locale;
+
 import com.sun.javafx.scene.control.GlobalMenuAdapter;
-import com.sun.javafx.stage.StageHelper;
+
 import de.codecentric.centerdevice.dialogs.about.AboutStageBuilder;
 import de.codecentric.centerdevice.glass.AdapterContext;
 import de.codecentric.centerdevice.glass.GlassAdaptionException;
@@ -26,10 +30,6 @@ import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
-
-import java.io.IOException;
-import java.util.Calendar;
-import java.util.Locale;
 
 public class MenuToolkit {
 	private static final String APP_NAME = "Apple";
@@ -174,7 +174,7 @@ public class MenuToolkit {
 	}
 
 	public void setMenuBar(MenuBar menuBar) {
-		StageHelper.getStages().forEach(stage -> setMenuBar(stage, menuBar));
+		StageUtils.getStages().forEach(stage -> setMenuBar(stage, menuBar));
 	}
 
 	public void setMenuBar(Stage stage, MenuBar menuBar) {
@@ -191,7 +191,7 @@ public class MenuToolkit {
 
 	public void autoAddWindowMenuItems(Menu menu) {
 		menu.getItems().add(new SeparatorMenuItem());
-		StageHelper.getStages().addListener(new WindowMenuUpdateListener(menu));
+		StageUtils.getStages().addListener(new WindowMenuUpdateListener(menu));
 	}
 
 	public void setForceQuitOnCmdQ(boolean forceQuit) {

--- a/src/main/java/de/codecentric/centerdevice/listener/MenuBarSyncListener.java
+++ b/src/main/java/de/codecentric/centerdevice/listener/MenuBarSyncListener.java
@@ -1,8 +1,7 @@
 package de.codecentric.centerdevice.listener;
 
-import com.sun.javafx.stage.StageHelper;
-
 import de.codecentric.centerdevice.util.MenuBarUtils;
+import de.codecentric.centerdevice.util.StageUtils;
 import javafx.collections.ListChangeListener;
 import javafx.scene.control.MenuBar;
 import javafx.stage.Stage;
@@ -17,13 +16,13 @@ public class MenuBarSyncListener implements ListChangeListener<Stage> {
 
 		if (instance == null) {
 			instance = new MenuBarSyncListener();
-			StageHelper.getStages().addListener(instance);
+			StageUtils.getStages().addListener(instance);
 		}
 	}
 
 	public static void unregister() {
 		if (instance != null) {
-			StageHelper.getStages().removeListener(instance);
+			StageUtils.getStages().removeListener(instance);
 			instance = null;
 		}
 	}

--- a/src/main/java/de/codecentric/centerdevice/listener/WindowMenuUpdateListener.java
+++ b/src/main/java/de/codecentric/centerdevice/listener/WindowMenuUpdateListener.java
@@ -1,6 +1,12 @@
 package de.codecentric.centerdevice.listener;
 
-import com.sun.javafx.stage.StageHelper;
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import de.codecentric.centerdevice.util.StageUtils;
 import javafx.beans.Observable;
 import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
@@ -10,12 +16,6 @@ import javafx.scene.control.CheckMenuItem;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.stage.Stage;
-
-import java.lang.ref.WeakReference;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 public class WindowMenuUpdateListener implements ListChangeListener<Stage> {
 
@@ -27,10 +27,10 @@ public class WindowMenuUpdateListener implements ListChangeListener<Stage> {
 		this.windowMenu = new WeakReference<>(windowMenu);
 		createdMenuItems = new HashMap<>();
 
-		addItemsToMenu(StageHelper.getStages());
+		addItemsToMenu(StageUtils.getStages());
 
 		stages = FXCollections.observableArrayList(stage -> new Observable[] {stage.focusedProperty()});
-		Bindings.bindContent(stages, StageHelper.getStages());
+		Bindings.bindContent(stages, StageUtils.getStages());
 
 		stages.addListener((Change <? extends Stage> c) -> checkFocusedStage());
 	}


### PR DESCRIPTION
I modified StageUtils to be comaptible with Java 8 and 9 and updated some other sources to actually use StageUtils instead of directly using StageHelper which does not work in Java 9 anymore.
Michael