### PR TITLE
Only update stages with actual changes

### DIFF
--- a/src/main/java/de/codecentric/centerdevice/util/StageUtils.java
+++ b/src/main/java/de/codecentric/centerdevice/util/StageUtils.java
@@ -88,13 +88,20 @@ public class StageUtils {
 	}
 
 	private static void updateStages() {
-		List<Stage> newStages = new LinkedList<>();
+		List<Stage> currentStages = new LinkedList<>();
 		for (Window w : windows) {
 			if (w instanceof Stage) {
-				newStages.add((Stage)w);
+				currentStages.add((Stage)w);
 			}
 		}
-		stages.setAll(newStages);		
+
+		// Remove no-longer existing stages
+		stages.removeIf(stage -> !currentStages.contains(stage));
+
+		// Add any new stages
+		currentStages.stream()
+				.filter(currentStage -> !stages.contains(currentStage))
+				.forEach(newStage -> stages.add(newStage));
 	}
 	
 	public static Optional<Stage> getFocusedStage() {


### PR DESCRIPTION
Instead of always updating stages with
```
  stages.setAll(newStages)
```
we now only update stages with the actual changes.

We first remove any removed stages and then add any newly created stages.

This avoids resetting the menubar on all stages when e.g. showing popup windows and thereby avoids flickering of the menubar.

Fixes #33