### PR TITLE
Add changelog section for 2.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.1.7
+
+## Bugfixes
+
+* Use standard reflection instead of method handles
+* Only update menu bar for stages with actual changes
+
 # 2.1.6
 
 ## Bugfixes


### PR DESCRIPTION
Thanks for merging a couple of PRs.

Since you updated the version number to 2.1.7 I thought it would be a good idea to update `CHANGELOG.md` with a section for that version.

Do you have any plans for making a 2.1.7 release?