### PR TITLE
Update for Big Sur

### DIFF
--- a/src/main/java/de/codecentric/centerdevice/MenuToolkit.java
+++ b/src/main/java/de/codecentric/centerdevice/MenuToolkit.java
@@ -82,7 +82,7 @@ public class MenuToolkit {
 
 		try {
 			IcnsParser parser = IcnsParser.forFile(AboutStageBuilder.DEFAULT_APP_ICON);
-			stageBuilder = stageBuilder.withImage(new Image(parser.getIconStream(IcnsType.ic08)));
+			stageBuilder = stageBuilder.withImage(new Image(parser.getIconStream(IcnsType.ic09)));
 		} catch (IOException e) {
 			// Too bad, cannot load dummy image
 		}


### PR DESCRIPTION
As issue #37 points out, an NPE is thrown from attemping to get an Image from an ic08-type icon, which is not available for the icon in question on Big Sur. This commit switches to parsing ic09, which is available on both Mac Catalina and Big Sur.